### PR TITLE
Require --insecure-allow-remote flag for non-localhost bind

### DIFF
--- a/cmd/service/main_test.go
+++ b/cmd/service/main_test.go
@@ -1,0 +1,32 @@
+package main
+
+import "testing"
+
+func TestIsLocalhostAddr(t *testing.T) {
+	tests := []struct {
+		host     string
+		expected bool
+	}{
+		// Localhost addresses
+		{"127.0.0.1", true},
+		{"localhost", true},
+		{"::1", true},
+		{"", true},
+
+		// Non-localhost addresses
+		{"0.0.0.0", false},
+		{"192.168.1.1", false},
+		{"10.0.0.1", false},
+		{"172.16.0.1", false},
+		{"example.com", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.host, func(t *testing.T) {
+			got := isLocalhostAddr(tt.host)
+			if got != tt.expected {
+				t.Errorf("isLocalhostAddr(%q) = %v, want %v", tt.host, got, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Prevents accidental exposure of the unauthenticated API by refusing to bind to network-accessible addresses unless explicitly requested.

## Problem

If someone sets `PCA_HOST=0.0.0.0` (or any non-localhost address), the service becomes network-accessible without authentication. This could happen accidentally via misconfiguration.

## Solution

The service now refuses to start on non-localhost addresses unless `--insecure-allow-remote` is passed:

```
$ PCA_HOST=0.0.0.0 proxmox-cpu-affinity-service

Error: Binding to non-localhost address "0.0.0.0" exposes an unauthenticated API.

This service has no authentication. Binding to a network-accessible address
allows any host on the network to trigger CPU affinity changes on your VMs.

If you understand the risks and want to proceed anyway, use:
    --insecure-allow-remote
```

With the flag, it starts with a warning:

```
$ PCA_HOST=0.0.0.0 proxmox-cpu-affinity-service --insecure-allow-remote
WARNING: Binding to "0.0.0.0" - unauthenticated API will be network-accessible!
```