### PR TITLE
fix: add build tags for cross-platform compilation

### DIFF
--- a/pkg/cpuinfo/cpuinfo.go
+++ b/pkg/cpuinfo/cpuinfo.go
@@ -12,9 +12,10 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
-
-	"golang.org/x/sys/unix"
 )
+
+// lockToCPU is defined in cpuinfo_linux.go for Linux
+// and cpuinfo_other.go for other platforms.
 
 // Provider defines the interface for CPU topology and ranking operations.
 type Provider interface {
@@ -248,15 +249,6 @@ func measureSingleLink(cpuA, cpuB, iter int) (float64, error) {
 	return float64(duration.Nanoseconds()) / float64(iter*2), nil
 }
 
-func lockToCPU(cpuID int) error {
-	runtime.LockOSThread()
-	var mask unix.CPUSet
-	mask.Set(cpuID)
-	if err := unix.SchedSetaffinity(0, &mask); err != nil {
-		return fmt.Errorf("failed to lock thread to CPU %d: %w", cpuID, err)
-	}
-	return nil
-}
 
 func readSysFSInt(path string) (int, error) {
 	realPath, err := filepath.EvalSymlinks(path)

--- a/pkg/cpuinfo/cpuinfo_linux.go
+++ b/pkg/cpuinfo/cpuinfo_linux.go
@@ -1,0 +1,20 @@
+//go:build linux
+
+package cpuinfo
+
+import (
+	"fmt"
+	"runtime"
+
+	"golang.org/x/sys/unix"
+)
+
+func lockToCPU(cpuID int) error {
+	runtime.LockOSThread()
+	var mask unix.CPUSet
+	mask.Set(cpuID)
+	if err := unix.SchedSetaffinity(0, &mask); err != nil {
+		return fmt.Errorf("failed to lock thread to CPU %d: %w", cpuID, err)
+	}
+	return nil
+}

--- a/pkg/cpuinfo/cpuinfo_other.go
+++ b/pkg/cpuinfo/cpuinfo_other.go
@@ -1,0 +1,11 @@
+//go:build !linux
+
+package cpuinfo
+
+import "errors"
+
+// lockToCPU is not supported on non-Linux platforms.
+// CPU affinity measurement requires Linux-specific syscalls.
+func lockToCPU(cpuID int) error {
+	return errors.New("CPU affinity is only supported on Linux")
+}

--- a/pkg/scheduler/affinity_linux.go
+++ b/pkg/scheduler/affinity_linux.go
@@ -1,0 +1,13 @@
+//go:build linux
+
+package scheduler
+
+import "golang.org/x/sys/unix"
+
+// CPUSet is an alias for the Linux-specific CPU affinity mask.
+type CPUSet = unix.CPUSet
+
+// schedSetaffinity wraps the Linux sched_setaffinity syscall.
+func schedSetaffinity(pid int, mask *CPUSet) error {
+	return unix.SchedSetaffinity(pid, mask)
+}

--- a/pkg/scheduler/affinity_other.go
+++ b/pkg/scheduler/affinity_other.go
@@ -1,0 +1,31 @@
+//go:build !linux
+
+package scheduler
+
+import "errors"
+
+// CPUSet is a stub type for non-Linux platforms.
+// The actual implementation only works on Linux.
+type CPUSet struct {
+	bits [16]uint64 // matches unix.CPUSet size
+}
+
+// Set marks cpu as part of the set.
+func (s *CPUSet) Set(cpu int) {
+	if cpu >= 0 && cpu < 1024 {
+		s.bits[cpu/64] |= 1 << (uint(cpu) % 64)
+	}
+}
+
+// IsSet reports whether cpu is part of the set.
+func (s *CPUSet) IsSet(cpu int) bool {
+	if cpu >= 0 && cpu < 1024 {
+		return s.bits[cpu/64]&(1<<(uint(cpu)%64)) != 0
+	}
+	return false
+}
+
+// schedSetaffinity is a stub that returns an error on non-Linux platforms.
+func schedSetaffinity(pid int, mask *CPUSet) error {
+	return errors.New("CPU affinity is only supported on Linux")
+}

--- a/pkg/scheduler/affinity_test.go
+++ b/pkg/scheduler/affinity_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
-	"golang.org/x/sys/unix"
 
 	"github.com/egandro/proxmox-cpu-affinity/pkg/config"
 	"github.com/egandro/proxmox-cpu-affinity/pkg/cpuinfo"
@@ -36,7 +35,7 @@ type MockSystemAffinityOps struct {
 	mock.Mock
 }
 
-func (m *MockSystemAffinityOps) SchedSetaffinity(pid int, mask *unix.CPUSet) error {
+func (m *MockSystemAffinityOps) SchedSetaffinity(pid int, mask *CPUSet) error {
 	args := m.Called(pid, mask)
 	return args.Error(0)
 }
@@ -109,7 +108,7 @@ func TestApplyAffinity(t *testing.T) {
 			setupMockSys: func(m *MockSystemAffinityOps) {
 				m.On("GetProcessThreads", 12345).Return([]int{12345}, nil)
 				m.On("GetChildProcesses", 12345).Return([]int{}, nil)
-				m.On("SchedSetaffinity", 12345, mock.MatchedBy(func(mask *unix.CPUSet) bool {
+				m.On("SchedSetaffinity", 12345, mock.MatchedBy(func(mask *CPUSet) bool {
 					return mask.IsSet(1) && mask.IsSet(0) && !mask.IsSet(2)
 				})).Return(nil)
 			},


### PR DESCRIPTION
## Summary
- Extracts Linux-specific syscall code (`unix.CPUSet`, `unix.SchedSetaffinity`) into `_linux.go` files
- Adds stub implementations in `_other.go` files that return errors on non-Linux platforms
- Allows the codebase to compile on macOS/Windows for development and testing

## Why
The code previously failed to compile on anything other than Linux due to direct `golang.org/x/sys/unix` imports. While this tool only *runs* on Proxmox (Linux), developers on macOS can now build and run tests locally.

## Test plan
- [x] `go build ./...` succeeds on macOS
- [x] `go test ./...` passes
- [x] Stub functions return appropriate errors on non-Linux