### PR TITLE
ci: add Dependabot for automated dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,27 @@
+version: 2
+updates:
+  # Keep Go modules up to date
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    groups:
+      # Group minor and patch updates together to reduce PR noise
+      go-minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
+    commit-message:
+      prefix: "deps"
+
+  # Keep GitHub Actions up to date
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "ci"


### PR DESCRIPTION
## Summary
- Adds `.github/dependabot.yml` configuration
- Weekly checks for Go module updates (grouped by minor/patch)
- Weekly checks for GitHub Actions updates
- Uses conventional commit prefixes (`deps:`, `ci:`)

## Why
Keeps dependencies fresh and security patches flowing in automatically.

## Test plan
- [x] Dependabot config is valid YAML
- [ ] Dependabot creates PRs after merge (manual verification)