### PR TITLE
ci: add govulncheck for vulnerability scanning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,12 @@ jobs:
         with:
           args: ./...
 
+      # 2b. Vulnerability Check
+      - name: Run govulncheck
+        run: |
+          go install golang.org/x/vuln/cmd/govulncheck@latest
+          govulncheck ./...
+
       # 3. Testing
       - name: Run Tests
         run: |


### PR DESCRIPTION
## Summary
- Adds govulncheck step to CI workflow
- Scans dependencies for known vulnerabilities on every PR and push

## Why
Catches vulnerable dependencies before they make it into production.

## Test plan
- [x] CI workflow includes govulncheck step
- [x] Current dependencies pass vulnerability check