### PR TITLE
refactor: propagate context through the call stack

### DIFF
--- a/pkg/proxmox/proxmox_test.go
+++ b/pkg/proxmox/proxmox_test.go
@@ -1,6 +1,7 @@
 package proxmox
 
 import (
+	"context"
 	"embed"
 	"fmt"
 	"os"
@@ -14,12 +15,12 @@ var testData embed.FS
 
 // MockExecutor implements Executor for testing purposes.
 type MockExecutor struct {
-	OutputFunc func(name string, arg ...string) ([]byte, error)
+	OutputFunc func(ctx context.Context, name string, arg ...string) ([]byte, error)
 }
 
-func (m *MockExecutor) Output(name string, arg ...string) ([]byte, error) {
+func (m *MockExecutor) Output(ctx context.Context, name string, arg ...string) ([]byte, error) {
 	if m.OutputFunc != nil {
-		return m.OutputFunc(name, arg...)
+		return m.OutputFunc(ctx, name, arg...)
 	}
 	return nil, fmt.Errorf("MockExecutor.OutputFunc not implemented")
 }
@@ -97,7 +98,7 @@ func TestGetVmConfig(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			mock := &MockExecutor{
-				OutputFunc: func(name string, arg ...string) ([]byte, error) {
+				OutputFunc: func(ctx context.Context, name string, arg ...string) ([]byte, error) {
 					if tt.mockError != nil {
 						return nil, tt.mockError
 					}
@@ -107,7 +108,7 @@ func TestGetVmConfig(t *testing.T) {
 
 			p := &proxmox{executor: mock}
 
-			config, err := p.GetVmConfig(tt.vmid)
+			config, err := p.GetVmConfig(context.Background(), tt.vmid)
 			if tt.expectError {
 				assert.Error(t, err)
 			} else {
@@ -168,7 +169,7 @@ func TestGetVmPid(t *testing.T) {
 				ProcessExistsFunc: tt.mockProcExist,
 			}
 			p := &proxmox{sys: mockSys}
-			got, err := p.GetVmPid(tt.vmid)
+			got, err := p.GetVmPid(context.Background(), tt.vmid)
 			if tt.expectError {
 				assert.Error(t, err)
 			} else {

--- a/pkg/scheduler/affinity.go
+++ b/pkg/scheduler/affinity.go
@@ -1,6 +1,7 @@
 package scheduler
 
 import (
+	"context"
 	"fmt"
 	"log/slog"
 	"os"
@@ -18,7 +19,7 @@ import (
 
 // affinityProvider defines the internal interface for affinity operations.
 type affinityProvider interface {
-	ApplyAffinity(vmid int, pid int, config *proxmox.VmConfig) (string, error)
+	ApplyAffinity(ctx context.Context, vmid int, pid int, config *proxmox.VmConfig) (string, error)
 }
 
 type cpuInfoProvider interface {
@@ -89,7 +90,7 @@ func newAffinityProvider(cfg *config.Config, cpuInfo cpuInfoProvider) affinityPr
 	}
 }
 
-func (a *defaultAffinityProvider) ApplyAffinity(vmid int, pid int, config *proxmox.VmConfig) (string, error) {
+func (a *defaultAffinityProvider) ApplyAffinity(_ context.Context, vmid int, pid int, config *proxmox.VmConfig) (string, error) {
 	a.affinityMu.Lock()
 	defer a.affinityMu.Unlock()
 

--- a/pkg/scheduler/affinity_test.go
+++ b/pkg/scheduler/affinity_test.go
@@ -1,6 +1,7 @@
 package scheduler
 
 import (
+	"context"
 	"errors"
 	"testing"
 
@@ -192,7 +193,7 @@ func TestApplyAffinity(t *testing.T) {
 				tt.setupMockSys(mockSys)
 			}
 
-			res, err := p.ApplyAffinity(tt.vmid, tt.pid, tt.config)
+			res, err := p.ApplyAffinity(context.Background(), tt.vmid, tt.pid, tt.config)
 
 			if tt.expectError {
 				// xxx

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -65,7 +65,7 @@ func (s *service) handleVmStarted(w http.ResponseWriter, r *http.Request) {
 		s.respond(w, http.StatusBadRequest, map[string]string{"error": "Invalid VMID"})
 		return
 	}
-	result, err := s.scheduler.VmStarted(vmid)
+	result, err := s.scheduler.VmStarted(r.Context(), vmid)
 	if err != nil {
 		s.respond(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
 		return

--- a/pkg/service/service_test.go
+++ b/pkg/service/service_test.go
@@ -19,8 +19,8 @@ type MockScheduler struct {
 	mock.Mock
 }
 
-func (m *MockScheduler) VmStarted(vmid int) (interface{}, error) {
-	args := m.Called(vmid)
+func (m *MockScheduler) VmStarted(ctx context.Context, vmid int) (interface{}, error) {
+	args := m.Called(ctx, vmid)
 	return args.Get(0), args.Error(1)
 }
 
@@ -103,7 +103,7 @@ func TestService_VmStarted(t *testing.T) {
 		"action": "start",
 		"mocked": true,
 	}
-	mockSched.On("VmStarted", 100).Return(expectedResult, nil)
+	mockSched.On("VmStarted", mock.Anything, 100).Return(expectedResult, nil)
 
 	url := fmt.Sprintf("%s/api/vmstarted/100", baseURL)
 	resp, err := http.Get(url)


### PR DESCRIPTION
## Summary
- Adds `context.Context` parameter to `Scheduler`, `ProxmoxClient`, and `affinityProvider` interfaces
- Passes request context from HTTP handlers through to Proxmox API calls
- Uses `exec.CommandContext` for cancellable command execution

## Why
Proper context propagation enables request cancellation and timeouts. When a client disconnects, we can stop any in-flight work instead of letting it run to completion.

## Dependencies
⚠️ Merge #10 (build-tags) first - this PR depends on the platform-specific files.

## Test plan
- [x] All existing tests pass
- [x] Context flows from HTTP handler to command execution